### PR TITLE
Fixed Typo that prevented bitmessagecurses from running!

### DIFF
--- a/src/bitmessagecurses/__init__.py
+++ b/src/bitmessagecurses/__init__.py
@@ -1027,7 +1027,7 @@ def run(stdscr):
             curses.init_pair(9, curses.COLOR_YELLOW, curses.COLOR_BLACK) # orangish
     
     # Init list of address in 'Your Identities' tab
-    configSections = BMConfigParser().addressses()
+    configSections = BMConfigParser().addresses()
     for addressInKeysFile in configSections:
         isEnabled = BMConfigParser().getboolean(addressInKeysFile, "enabled")
         addresses.append([BMConfigParser().get(addressInKeysFile, "label"), isEnabled, addressInKeysFile])


### PR DESCRIPTION
## Code contributions to the Bitmessage project

- try to explain what the code is about
- try to follow [PEP0008](https://www.python.org/dev/peps/pep-0008/)
- make the pull request against the ["v0.6" branch](https://github.com/Bitmessage/PyBitmessage/tree/v0.6)
- it should be possible to do a fast-forward merge of the pull requests
- PGP-sign the commits included in the pull request
- You can get paid for merged commits if you register at [Tip4Commit](https://tip4commit.com/github/Bitmessage/PyBitmessage)

If for some reason you don't want to use github, you can submit the patch using Bitmessage to the "bitmessage" chan, or to one of the developers.
## Translations

For helping with translations, please use [Transifex](https://www.transifex.com/bitmessage-project/pybitmessage/). There is no need to submit pull requests for translations.
For translating technical terms it is recommended to consult the [Microsoft Language Portal](https://www.microsoft.com/Language/en-US/Default.aspx).